### PR TITLE
Run GoodJob update migrations (rails g good_job:update)

### DIFF
--- a/db/migrate/20260623190255_add_jobs_finished_at_to_good_job_batches.rb
+++ b/db/migrate/20260623190255_add_jobs_finished_at_to_good_job_batches.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddJobsFinishedAtToGoodJobBatches < ActiveRecord::Migration[8.1]
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.column_exists?(:good_job_batches, :jobs_finished_at)
+      end
+    end
+
+    change_table :good_job_batches do |t|
+      t.datetime :jobs_finished_at
+    end
+  end
+end

--- a/db/migrate/20260623190256_add_index_good_jobs_concurrency_key_created_at.rb
+++ b/db/migrate/20260623190256_add_index_good_jobs_concurrency_key_created_at.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsConcurrencyKeyCreatedAt < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_exists? :good_jobs, [:concurrency_key, :created_at]
+      end
+    end
+
+    add_index :good_jobs, [:concurrency_key, :created_at], algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260623190257_add_index_good_jobs_job_class.rb
+++ b/db/migrate/20260623190257_add_index_good_jobs_job_class.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsJobClass < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_exists? :good_jobs, :job_class
+      end
+    end
+
+    add_index :good_jobs, :job_class, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260623190258_add_index_good_jobs_finished_at_for_cleanup.rb
+++ b/db/migrate/20260623190258_add_index_good_jobs_finished_at_for_cleanup.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsFinishedAtForCleanup < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_exists? :good_jobs, [:finished_at], name: :index_good_jobs_jobs_on_finished_at_only
+      end
+    end
+
+    add_index :good_jobs, [:finished_at], where: "finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at_only, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260623190259_remove_extraneous_finished_at_index.rb
+++ b/db/migrate/20260623190259_remove_extraneous_finished_at_index.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class RemoveExtraneousFinishedAtIndex < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return unless connection.index_exists? :good_jobs, [:finished_at], name: :index_good_jobs_jobs_on_finished_at
+      end
+    end
+
+    remove_index :good_jobs, [:finished_at], where: "retried_good_job_id IS NULL AND finished_at IS NOT NULL", name: :index_good_jobs_jobs_on_finished_at, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260623190260_add_lock_type_to_good_jobs.rb
+++ b/db/migrate/20260623190260_add_lock_type_to_good_jobs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddLockTypeToGoodJobs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :good_jobs, :lock_type, :integer, limit: 2 unless column_exists?(:good_jobs, :lock_type)
+  end
+end

--- a/db/migrate/20260623190261_add_index_good_jobs_for_candidate_dequeue_unlocked.rb
+++ b/db/migrate/20260623190261_add_index_good_jobs_for_candidate_dequeue_unlocked.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsForCandidateDequeueUnlocked < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, [:priority, :scheduled_at, :id],
+      name: :index_good_jobs_for_candidate_dequeue_unlocked,
+      order: { priority: "ASC NULLS LAST", scheduled_at: :asc, id: :asc },
+      where: "finished_at IS NULL AND locked_by_id IS NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260623190262_add_index_good_jobs_priority_scheduled_at.rb
+++ b/db/migrate/20260623190262_add_index_good_jobs_priority_scheduled_at.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsPriorityScheduledAt < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    reversible do |dir|
+      dir.up do
+        # Ensure this incremental update migration is idempotent
+        # with monolithic install migration.
+        return if connection.index_name_exists?(:good_jobs, "index_good_jobs_on_priority_scheduled_at_unfinished") &&
+                  connection.index_name_exists?(:good_jobs, "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished")
+      end
+    end
+
+    add_index :good_jobs, [:priority, :scheduled_at, :id],
+                                                      where: "finished_at IS NULL", name: "index_good_jobs_on_priority_scheduled_at_unfinished",
+                                                      algorithm: :concurrently
+    add_index :good_jobs, [:queue_name, :scheduled_at, :id],
+                                                      where: "finished_at IS NULL", name: "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished",
+                                                      algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260623190263_add_index_good_jobs_queue_name.rb
+++ b/db/migrate/20260623190263_add_index_good_jobs_queue_name.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsQueueName < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :queue_name,
+      name: :index_good_jobs_on_queue_name,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260623190264_add_index_good_jobs_created_at.rb
+++ b/db/migrate/20260623190264_add_index_good_jobs_created_at.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsCreatedAt < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :created_at,
+      name: :index_good_jobs_on_created_at,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260623190265_add_index_good_jobs_discarded.rb
+++ b/db/migrate/20260623190265_add_index_good_jobs_discarded.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsDiscarded < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :finished_at,
+      name: :index_good_jobs_on_discarded,
+      order: { finished_at: :desc },
+      where: "finished_at IS NOT NULL AND error IS NOT NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260623190266_add_index_good_jobs_scheduled_at_and_queue_name.rb
+++ b/db/migrate/20260623190266_add_index_good_jobs_scheduled_at_and_queue_name.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsScheduledAtAndQueueName < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, [:scheduled_at, :queue_name],
+      name: :index_good_jobs_on_scheduled_at_and_queue_name,
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/migrate/20260623190267_add_index_good_jobs_on_unfinished_or_errored.rb
+++ b/db/migrate/20260623190267_add_index_good_jobs_on_unfinished_or_errored.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddIndexGoodJobsOnUnfinishedOrErrored < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :good_jobs, :id,
+      name: :index_good_jobs_on_unfinished_or_errored,
+      where: "finished_at IS NULL OR error IS NOT NULL",
+      algorithm: :concurrently,
+      if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2024_07_30_192533) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_23_190267) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -33,6 +33,7 @@ ActiveRecord::Schema[8.1].define(version: 2024_07_30_192533) do
     t.datetime "discarded_at"
     t.datetime "enqueued_at"
     t.datetime "finished_at"
+    t.datetime "jobs_finished_at"
     t.text "on_discard"
     t.text "on_finish"
     t.text "on_success"
@@ -88,6 +89,7 @@ ActiveRecord::Schema[8.1].define(version: 2024_07_30_192533) do
     t.boolean "is_discrete"
     t.text "job_class"
     t.text "labels", array: true
+    t.integer "lock_type", limit: 2
     t.datetime "locked_at"
     t.uuid "locked_by_id"
     t.datetime "performed_at"
@@ -100,16 +102,26 @@ ActiveRecord::Schema[8.1].define(version: 2024_07_30_192533) do
     t.index ["active_job_id", "created_at"], name: "index_good_jobs_on_active_job_id_and_created_at"
     t.index ["batch_callback_id"], name: "index_good_jobs_on_batch_callback_id", where: "(batch_callback_id IS NOT NULL)"
     t.index ["batch_id"], name: "index_good_jobs_on_batch_id", where: "(batch_id IS NOT NULL)"
+    t.index ["concurrency_key", "created_at"], name: "index_good_jobs_on_concurrency_key_and_created_at"
     t.index ["concurrency_key"], name: "index_good_jobs_on_concurrency_key_when_unfinished", where: "(finished_at IS NULL)"
+    t.index ["created_at"], name: "index_good_jobs_on_created_at"
     t.index ["cron_key", "created_at"], name: "index_good_jobs_on_cron_key_and_created_at_cond", where: "(cron_key IS NOT NULL)"
     t.index ["cron_key", "cron_at"], name: "index_good_jobs_on_cron_key_and_cron_at_cond", unique: true, where: "(cron_key IS NOT NULL)"
-    t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at", where: "((retried_good_job_id IS NULL) AND (finished_at IS NOT NULL))"
+    t.index ["finished_at"], name: "index_good_jobs_jobs_on_finished_at_only", where: "(finished_at IS NOT NULL)"
+    t.index ["finished_at"], name: "index_good_jobs_on_discarded", order: :desc, where: "((finished_at IS NOT NULL) AND (error IS NOT NULL))"
+    t.index ["id"], name: "index_good_jobs_on_unfinished_or_errored", where: "((finished_at IS NULL) OR (error IS NOT NULL))"
+    t.index ["job_class"], name: "index_good_jobs_on_job_class"
     t.index ["labels"], name: "index_good_jobs_on_labels", where: "(labels IS NOT NULL)", using: :gin
     t.index ["locked_by_id"], name: "index_good_jobs_on_locked_by_id", where: "(locked_by_id IS NOT NULL)"
     t.index ["priority", "created_at"], name: "index_good_job_jobs_for_candidate_lookup", where: "(finished_at IS NULL)"
     t.index ["priority", "created_at"], name: "index_good_jobs_jobs_on_priority_created_at_when_unfinished", order: { priority: "DESC NULLS LAST" }, where: "(finished_at IS NULL)"
+    t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_for_candidate_dequeue_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["priority", "scheduled_at", "id"], name: "index_good_jobs_on_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
     t.index ["priority", "scheduled_at"], name: "index_good_jobs_on_priority_scheduled_at_unfinished_unlocked", where: "((finished_at IS NULL) AND (locked_by_id IS NULL))"
+    t.index ["queue_name", "scheduled_at", "id"], name: "index_good_jobs_on_queue_name_priority_scheduled_at_unfinished", where: "(finished_at IS NULL)"
     t.index ["queue_name", "scheduled_at"], name: "index_good_jobs_on_queue_name_and_scheduled_at", where: "(finished_at IS NULL)"
+    t.index ["queue_name"], name: "index_good_jobs_on_queue_name"
+    t.index ["scheduled_at", "queue_name"], name: "index_good_jobs_on_scheduled_at_and_queue_name"
     t.index ["scheduled_at"], name: "index_good_jobs_on_scheduled_at", where: "(finished_at IS NULL)"
   end
 


### PR DESCRIPTION
Runs the GoodJob update generator (`rails g good_job:update`) to add migrations compatible with GoodJob v4.19.

Adds a `jobs_finished_at` column to `good_job_batches` and a `lock_type` column to `good_jobs`. Also adds 11 new indexes to `good_jobs` for improved query performance including indexes on `job_class`, `concurrency_key`, `queue_name`, `created_at`, `scheduled_at`, and candidate dequeue/cleanup paths.