### PR TITLE
Convert RefreshJob to a GoodJob batch

### DIFF
--- a/app/jobs/refresh_job.rb
+++ b/app/jobs/refresh_job.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
 class RefreshJob < ApplicationJob
-  def perform
-    City.find_each do |city|
-      FetchServiceRequestsJob.perform_later(city)
-      FetchServiceListJob.perform_later(city)
+  class OnFinishJob < ApplicationJob
+    def perform(_batch, _context)
+      GlobalIndex.refresh
     end
-    GlobalIndex.refresh # TODO: this should ideally happen after all the jobs are done
+  end
+
+  def perform
+    GoodJob::Batch.enqueue(self, on_finish: OnFinishJob) do
+      City.find_each do |city|
+        FetchServiceRequestsJob.perform_later(city)
+        FetchServiceListJob.perform_later(city)
+      end
+    end
   end
 end

--- a/spec/jobs/refresh_job_spec.rb
+++ b/spec/jobs/refresh_job_spec.rb
@@ -5,14 +5,29 @@ RSpec.describe RefreshJob do
   let!(:city) { City.instance('chicago') }
 
   describe '#perform' do
-    before do
-      ActiveJob::Base.queue_adapter = :test
+    it 'enqueues a bunch of jobs for each city, then refreshes the global index once they finish' do
+      api_double = instance_double City::Api, fetch_service_requests: [], fetch_service_list: []
+      allow(City::Api).to receive(:new).with(city).and_return(api_double)
+      allow(GlobalIndex).to receive(:refresh)
+
+      described_class.perform_later
+
+      expect(api_double).to have_received(:fetch_service_requests)
+      expect(api_double).to have_received(:fetch_service_list)
+      expect(GlobalIndex).to have_received(:refresh)
     end
 
-    it 'enqueues a bunch of jobs for each city' do
-      expect { described_class.perform_now }
-        .to have_enqueued_job(FetchServiceRequestsJob).with(city)
-        .and have_enqueued_job(FetchServiceListJob).with(city)
+    it 'adds itself and all the per-city jobs to the same batch' do
+      api_double = instance_double City::Api, fetch_service_requests: [], fetch_service_list: []
+      allow(City::Api).to receive(:new).with(city).and_return(api_double)
+      allow(GlobalIndex).to receive(:refresh)
+
+      described_class.perform_later
+
+      batch_id = GoodJob::Job.find_by!(job_class: 'RefreshJob').batch_id
+      expect(batch_id).to be_present
+      expect(GoodJob::Job.where(job_class: 'FetchServiceRequestsJob').pluck(:batch_id)).to all(eq(batch_id))
+      expect(GoodJob::Job.where(job_class: 'FetchServiceListJob').pluck(:batch_id)).to all(eq(batch_id))
     end
   end
 end


### PR DESCRIPTION
## Summary
- `RefreshJob` now enqueues the per-city `FetchServiceRequestsJob`/`FetchServiceListJob` jobs (and includes itself) inside a `GoodJob::Batch`.
- `GlobalIndex.refresh` is moved into a new `RefreshJob::OnFinishJob` batch callback, so it only runs once all jobs in the batch have finished, instead of firing immediately after enqueuing (removing the prior TODO/race condition).

## Test plan
- [x] `bundle exec rspec spec/jobs/refresh_job_spec.rb`
- [x] `bundle exec rubocop app/jobs/refresh_job.rb spec/jobs/refresh_job_spec.rb`